### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cogprime-build.yml
+++ b/.github/workflows/cogprime-build.yml
@@ -7,6 +7,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: read
+  actions: read
+
 env:
   CCACHE_DIR: /workspace/ccache
   CMAKE_BUILD_TYPE: Release


### PR DESCRIPTION
Potential fix for [https://github.com/drzo/opencog-central/security/code-scanning/10](https://github.com/drzo/opencog-central/security/code-scanning/10)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required. Based on the actions used in the workflow, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `packages: read` for downloading dependencies or artifacts.
- `actions: read` for interacting with GitHub Actions artifacts.

This ensures that the workflow has only the permissions it needs and no unnecessary write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to clarify permissions for improved transparency. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->